### PR TITLE
Use bash syntax for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ FROM fsfe/reuse:latest
 WORKDIR /github/workspace
 
 # Run reuse lint
-ENTRYPOINT ["reuse"]
+ENTRYPOINT "reuse"


### PR DESCRIPTION
I *think* that this may fix the issue described in #3 where you can't provide multiple arguments.