### PR TITLE
Remove `cmd`, use `args` instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ WORKDIR /github/workspace
 
 # Run reuse lint
 ENTRYPOINT ["reuse"]
+CMD ["lint"]

--- a/README.md
+++ b/README.md
@@ -46,16 +46,14 @@ If you would like to run other subcommands, you could use the following snippet 
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@master
       with:
-        cmd: 'spdx'
+        args: spdx
 ```
-
-Please note that due to Github restrictions it is not possible to pass extra arguments like `--include-submodules` to the `cmd` input.
 
 ## Inputs Description
 
-| Name  | Requirement | Default | Description |
-| ----- | ----------- | ------- | ----------- |
-| `cmd` | _required_  | `lint`  | The subcommand for the REUSE helper tool. Read the [tool's documentation](https://reuse.readthedocs.io/) for all available subcommands. |
+| Name   | Requirement | Default | Description |
+| ------ | ----------- | ------- | ----------- |
+| `args` | _required_  | `lint`  | The subcommand for the REUSE helper tool. Read the [tool's documentation](https://reuse.readthedocs.io/) for all available subcommands. |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -5,16 +5,9 @@
 name: 'REUSE Compliance Check'
 description: "Check your project's REUSE compliance for clear and simple licensing and copyright!"
 author: 'Free Software Foundation Europe (FSFE)'
-inputs:
-  cmd:
-    description: 'Subcommand'
-    required: true
-    default: 'lint'
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.cmd }}
 branding:
   icon: 'check-circle'
   color: 'green'


### PR DESCRIPTION
Turns out `args` is a built-in variable that can be used to append arguments to a Docker command.

This change requires reuse >=0.10.0

Overrides #4, fixes #3 