### PR TITLE
Fix undetectable Git repository due to different owners

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,8 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: REUSE Compliance Check
+    - uses: actions/checkout@v3
+    - name: REUSE version
+      uses: ./
+      with:
+        args: --version
+    - name: REUSE lint
       uses: ./
       with:
         args: --include-submodules lint
+    - name: REUSE SPDX SBOM
+      uses: ./
+      with:
+        args: spdx

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 
 FROM fsfe/reuse:latest
 
-# Go to automatically mounted workspace
-WORKDIR /github/workspace
+# Copy reuse wrapper used as entrypoint
+COPY reuse-action-wrapper.sh /bin/reuse-action-wrapper
 
 # Run reuse lint
-ENTRYPOINT ["reuse"]
+ENTRYPOINT ["/bin/reuse-action-wrapper"]
 CMD ["lint"]

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    steps: 
-    - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v3
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1
 ```
@@ -47,8 +47,8 @@ jobs:
 If you would like to run other subcommands, you could use the following snippet which outputs a the SPDX bill of materials:
 
 ```yml
-    - uses: actions/checkout@v2
-    - name: REUSE Compliance Check
+    - uses: actions/checkout@v3
+    - name: REUSE SPDX SBOM
       uses: fsfe/reuse-action@v1
       with:
         args: spdx
@@ -57,7 +57,7 @@ If you would like to run other subcommands, you could use the following snippet 
 In the same fashion, it is possible to add optional arguments like `--include-submodules`:
 
 ```yml
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1
       with:

--- a/reuse-action-wrapper.sh
+++ b/reuse-action-wrapper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Set workspace directory as safe Git directory
+# See https://github.blog/2022-04-12-git-security-vulnerability-announced/
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+# Enter directory
+cd "$GITHUB_WORKSPACE" || exit 1
+
+# Run REUSE
+reuse "$@"


### PR DESCRIPTION
Implement a wrapper as entrypoint that sets the correct Git permissions by setting the workspace as a safe directory.

Additionally we do no longer hard-code the workspace directory but use the environment variable.

Fixes #17 