### PR TITLE
Avoid code-scan alert

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -10,6 +10,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   # Use local file to test against itself
   test-self:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   reuse-compliance-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Default GH code scan flags missing permissions:

![image](https://github.com/user-attachments/assets/d41f3ac6-4d0b-42d7-90e7-c1143133869f)

The change avoids this issue