### PR TITLE
Add workflow_call to actions workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can include the following lines in your workflow .yml file to run the lint s
 ---
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 
 permissions:
   contents: read


### PR DESCRIPTION
Allows the workflow to be called from another workflow.

I copied the given example into its own workflow inside our `.github` repository of our organization. [Calling it from another workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow) didn't work because `workflow_call` was missing. 

Not necessary, but could be nice to have this in the example.